### PR TITLE
Allow more than 3 sorts using dynamic query

### DIFF
--- a/test/absinthe_relay_keyset_connection_test.exs
+++ b/test/absinthe_relay_keyset_connection_test.exs
@@ -1144,25 +1144,6 @@ defmodule AbsintheRelayKeysetConnectionTest do
       assert msg =~ "sorts"
     end
 
-    test "does not allow more than 3 sorts" do
-      assert {:error, msg} =
-               KC.from_query(
-                 User,
-                 &Repo.all/1,
-                 %{
-                   sorts: [
-                     %{last_name: :asc},
-                     %{bite_strength: :desc},
-                     %{haiku_ability: :asc},
-                     %{id: :asc}
-                   ],
-                   first: 3
-                 }
-               )
-
-      assert msg =~ "more than 3 sorts are not supported"
-    end
-
     test "errors when one map contains multiple sorts" do
       assert {:error, {:invalid_sorts, msg}} =
                KC.from_query(


### PR DESCRIPTION
This is a derivative from #1, but only includes changes to allow dynamic queries, removing the limit of 3 sorts, and reducing query complexity.