### PR TITLE
Allow using a custom Cursor implementation

### DIFF
--- a/lib/absinthe_relay_keyset_connection/cursor_translator.ex
+++ b/lib/absinthe_relay_keyset_connection/cursor_translator.ex
@@ -1,0 +1,59 @@
+defmodule AbsintheRelayKeysetConnection.CursorTranslator do
+  @moduledoc """
+  A cursor translator handles encoding and decoding pagination cursors.
+
+  This module provides the behaviour for implementing a cursor translator.
+  An example use case of this module would be a cursor translator that
+  encodes and decodes signed or encrypted pagination cursors.
+
+  ## Example Cursor Translator
+
+  A basic example that encodes and decodes cursors using Jason and base64:
+
+  ```elixir
+  defmodule MyApp.Absinthe.Cursor do
+    @behaviour AbsintheRelayKeysetConnection.CursorTranslator
+
+    @impl AbsintheRelayKeysetConnection.CursorTranslator
+    def from_key(key_map, cursor_columns) do
+      cursor_columns
+      |> Enum.map(&Map.fetch!(key_map, &1))
+      |> Jason.encode!()
+      |> Base.encode64(padding: false)
+    end
+
+    @impl AbsintheRelayKeysetConnection.CursorTranslator
+    def to_key(encoded_cursor, expected_columns) do
+      values = encoded_cursor |> Base.decode64!(padding: false) |> Jason.decode!()
+      key = expected_columns |> Enum.zip(values) |> Map.new()
+
+      {:ok, key}
+    end
+  end
+  ```
+  """
+
+  @typedoc "A key of the column of the node being paginated."
+  @type column_key() :: atom() | String.t()
+
+  @typedoc "A map containing the node data."
+  @type key_map() :: %{required(column_key()) => term()}
+
+  @typedoc "A string containing the encoded cursor."
+  @type encoded_cursor() :: String.t()
+
+  @doc """
+  Creates the cursor string from a key.
+
+  Converts a key map into a cursor string using the given cursor columns.
+  """
+  @callback from_key(key_map(), [column_key()]) :: encoded_cursor()
+
+  @doc """
+  Rederives the key from the cursor string.
+
+  Converts a cursor string into a key map using the given cursor columns.
+  """
+  @callback to_key(encoded_cursor(), expected_columns :: [column_key()]) ::
+              {:ok, key_map()} | {:error, term()}
+end

--- a/test/absinthe_relay_keyset_connection/cursor_translator/base64_hashed_test.exs
+++ b/test/absinthe_relay_keyset_connection/cursor_translator/base64_hashed_test.exs
@@ -1,33 +1,33 @@
-defmodule AbsintheRelayKeysetConnection.CursorTest do
+defmodule AbsintheRelayKeysetConnection.CursorTranslator.Base64HashedTest do
   use ExUnit.Case, async: true
 
-  alias AbsintheRelayKeysetConnection.Cursor
-  doctest Cursor, import: true
+  alias AbsintheRelayKeysetConnection.CursorTranslator.Base64Hashed
+  doctest Base64Hashed, import: true
 
   describe "encoding and decoding cursors, ensuring valid columns" do
     test "with an id column" do
       raw = %{id: 1}
-      encoded = Cursor.from_key(raw, [:id])
-      {:ok, decoded} = Cursor.to_key(encoded, [:id])
+      encoded = Base64Hashed.from_key(raw, [:id])
+      {:ok, decoded} = Base64Hashed.to_key(encoded, [:id])
       assert decoded == raw
     end
 
     test "with multiple columns combined for uniqueness" do
       expected_columns = [:last_name, :id]
       raw = %{last_name: "Smithers", id: 50}
-      encoded = Cursor.from_key(raw, expected_columns)
+      encoded = Base64Hashed.from_key(raw, expected_columns)
 
       # If these are the exact columns we expect, it's valid
-      {:ok, decoded} = Cursor.to_key(encoded, expected_columns)
+      {:ok, decoded} = Base64Hashed.to_key(encoded, expected_columns)
       assert decoded == raw
 
       # If there are columns we don't expect, it's invalid
       expected_columns = [:id]
-      {:error, :invalid_cursor} = Cursor.to_key(encoded, expected_columns)
+      {:error, :invalid_cursor} = Base64Hashed.to_key(encoded, expected_columns)
 
       # If these are not all the columns we expect, it's invalid
       expected_columns = [:last_name, :first_name, :id]
-      {:error, :invalid_cursor} = Cursor.to_key(encoded, expected_columns)
+      {:error, :invalid_cursor} = Base64Hashed.to_key(encoded, expected_columns)
     end
   end
 end

--- a/test/absinthe_relay_keyset_connection_test.exs
+++ b/test/absinthe_relay_keyset_connection_test.exs
@@ -1144,25 +1144,6 @@ defmodule AbsintheRelayKeysetConnectionTest do
       assert msg =~ "sorts"
     end
 
-    test "does not allow more than 3 sorts" do
-      assert {:error, msg} =
-               KC.from_query(
-                 User,
-                 &Repo.all/1,
-                 %{
-                   sorts: [
-                     %{last_name: :asc},
-                     %{bite_strength: :desc},
-                     %{haiku_ability: :asc},
-                     %{id: :asc}
-                   ],
-                   first: 3
-                 }
-               )
-
-      assert msg =~ "more than 3 sorts are not supported"
-    end
-
     test "errors when one map contains multiple sorts" do
       assert {:error, {:invalid_sorts, msg}} =
                KC.from_query(


### PR DESCRIPTION
This PR builds on top of #2, since it includes similar code style changes.

This adds a `CursorTranslator` behaviour. The `Base64Hashed` Cursor implements this behaviour, but users of this library can pass their own module as long as it implements the `CursorTranslator` behaviour.

This also alters the default cursor implementation to check the checksum. This makes it "A tamper-resistant (not tamper-proof) implementation that uses base64 and a hashed padding.". This should not (but can be considered to) be a breaking change.