### PR TITLE
Allow coalescing to avoid crashing with NULL values

### DIFF
--- a/lib/absinthe_relay_keyset_connection.ex
+++ b/lib/absinthe_relay_keyset_connection.ex
@@ -115,7 +115,7 @@ defmodule AbsintheRelayKeysetConnection do
 
   By default, NULL values in sortable columns can cause pagination to fail because
   SQL comparisons with NULL (like `WHERE name > NULL`) are unsafe and forbidden by Ecto.
-  
+
   To handle this, you can use the `:null_coalesce` configuration option to specify
   replacement values for NULL columns during sorting and cursor operations.
 
@@ -551,16 +551,22 @@ defmodule AbsintheRelayKeysetConnection do
   defp apply_sort(query, field, dir_and_flip, null_coalesce)
        when dir_and_flip in [{:asc, false}, {:desc, true}] do
     case Map.get(null_coalesce, field) do
-      nil -> Ecto.Query.order_by(query, [q], asc: field(q, ^field))
-      coalesce_value -> Ecto.Query.order_by(query, [q], asc: coalesce(field(q, ^field), ^coalesce_value))
+      nil ->
+        Ecto.Query.order_by(query, [q], asc: field(q, ^field))
+
+      coalesce_value ->
+        Ecto.Query.order_by(query, [q], asc: coalesce(field(q, ^field), ^coalesce_value))
     end
   end
 
   defp apply_sort(query, field, dir_and_flip, null_coalesce)
        when dir_and_flip in [{:desc, false}, {:asc, true}] do
     case Map.get(null_coalesce, field) do
-      nil -> Ecto.Query.order_by(query, [q], desc: field(q, ^field))
-      coalesce_value -> Ecto.Query.order_by(query, [q], desc: coalesce(field(q, ^field), ^coalesce_value))
+      nil ->
+        Ecto.Query.order_by(query, [q], desc: field(q, ^field))
+
+      coalesce_value ->
+        Ecto.Query.order_by(query, [q], desc: coalesce(field(q, ^field), ^coalesce_value))
     end
   end
 
@@ -671,12 +677,27 @@ defmodule AbsintheRelayKeysetConnection do
           :< -> Ecto.Query.dynamic([q], field(q, ^col_name) < ^column_value)
           :== -> Ecto.Query.dynamic([q], field(q, ^col_name) == ^column_value)
         end
+
       coalesce_value ->
         # Use COALESCE for this column
         case op do
-          :> -> Ecto.Query.dynamic([q], coalesce(field(q, ^col_name), ^coalesce_value) > ^column_value)
-          :< -> Ecto.Query.dynamic([q], coalesce(field(q, ^col_name), ^coalesce_value) < ^column_value)
-          :== -> Ecto.Query.dynamic([q], coalesce(field(q, ^col_name), ^coalesce_value) == ^column_value)
+          :> ->
+            Ecto.Query.dynamic(
+              [q],
+              coalesce(field(q, ^col_name), ^coalesce_value) > ^column_value
+            )
+
+          :< ->
+            Ecto.Query.dynamic(
+              [q],
+              coalesce(field(q, ^col_name), ^coalesce_value) < ^column_value
+            )
+
+          :== ->
+            Ecto.Query.dynamic(
+              [q],
+              coalesce(field(q, ^col_name), ^coalesce_value) == ^column_value
+            )
         end
     end
   end

--- a/lib/absinthe_relay_keyset_connection/cursor_translator.ex
+++ b/lib/absinthe_relay_keyset_connection/cursor_translator.ex
@@ -15,15 +15,26 @@ defmodule AbsintheRelayKeysetConnection.CursorTranslator do
     @behaviour AbsintheRelayKeysetConnection.CursorTranslator
 
     @impl AbsintheRelayKeysetConnection.CursorTranslator
-    def from_key(key_map, cursor_columns) do
-      cursor_columns
-      |> Enum.map(&Map.fetch!(key_map, &1))
+    def from_key(key_map, cursor_columns, config \\ %{}) do
+      null_coalesce = Map.get(config, :null_coalesce, %{})
+      
+      values = 
+        cursor_columns
+        |> Enum.map(fn column ->
+          value = Map.fetch!(key_map, column)
+          case value do
+            nil -> Map.get(null_coalesce, column, nil)
+            _ -> value
+          end
+        end)
+      
+      values
       |> Jason.encode!()
       |> Base.encode64(padding: false)
     end
 
     @impl AbsintheRelayKeysetConnection.CursorTranslator
-    def to_key(encoded_cursor, expected_columns) do
+    def to_key(encoded_cursor, expected_columns, _config \\ %{}) do
       values = encoded_cursor |> Base.decode64!(padding: false) |> Jason.decode!()
       key = expected_columns |> Enum.zip(values) |> Map.new()
 
@@ -50,10 +61,35 @@ defmodule AbsintheRelayKeysetConnection.CursorTranslator do
   @callback from_key(key_map(), [column_key()]) :: encoded_cursor()
 
   @doc """
+  Creates the cursor string from a key with additional configuration.
+
+  Converts a key map into a cursor string using the given cursor columns,
+  applying any configured transformations like null coalescing.
+
+  ## Configuration Options
+
+  - `:null_coalesce` - Map of column names to coalesce values for NULL handling
+  """
+  @callback from_key(key_map(), [column_key()], config :: map()) :: encoded_cursor()
+
+  @doc """
   Rederives the key from the cursor string.
 
   Converts a cursor string into a key map using the given cursor columns.
   """
   @callback to_key(encoded_cursor(), expected_columns :: [column_key()]) ::
+              {:ok, key_map()} | {:error, term()}
+
+  @doc """
+  Rederives the key from the cursor string with additional configuration.
+
+  Converts a cursor string into a key map using the given cursor columns,
+  applying any configured transformations like null coalescing.
+
+  ## Configuration Options
+
+  - `:null_coalesce` - Map of column names to coalesce values for NULL handling
+  """
+  @callback to_key(encoded_cursor(), expected_columns :: [column_key()], config :: map()) ::
               {:ok, key_map()} | {:error, term()}
 end

--- a/test/absinthe_relay_keyset_connection_test.exs
+++ b/test/absinthe_relay_keyset_connection_test.exs
@@ -1176,4 +1176,236 @@ defmodule AbsintheRelayKeysetConnectionTest do
     {^expected_count, nil} = Repo.insert_all(User, data)
     Users.all()
   end
+
+  describe "handling NULL values in sortable columns" do
+    test "crashes when navigating with NULL values without coalescing" do
+      # Insert 4 users where ALL values in the sorted column are NULL
+      insert_users([
+        %{id: 1, first_name: "Alice", last_name: nil},
+        %{id: 2, first_name: "Bob", last_name: nil},
+        %{id: 3, first_name: "Charlie", last_name: nil},
+        %{id: 4, first_name: "David", last_name: nil}
+      ])
+
+      # Get first page - this works
+      assert {:ok, %{edges: first_page, page_info: page_info}} =
+               KC.from_query(
+                 User,
+                 &Repo.all/1,
+                 %{
+                   sorts: [%{last_name: :asc}],
+                   first: 2
+                 },
+                 %{unique_column: :id}
+               )
+
+      assert length(first_page) == 2
+      assert page_info.has_next_page == true
+
+      # Try to navigate to second page - this crashes because cursor contains NULL
+      assert_raise ArgumentError, ~r/comparing.*with.*nil.*is forbidden/, fn ->
+        KC.from_query(
+          User,
+          &Repo.all/1,
+          %{
+            sorts: [%{last_name: :asc}],
+            first: 2,
+            after: page_info.end_cursor
+          },
+          %{unique_column: :id}
+        )
+      end
+    end
+
+    test "works correctly with NULL values when using null coalescing" do
+      # Insert 4 users where ALL values in the sorted column are NULL
+      insert_users([
+        %{id: 1, first_name: "Alice", last_name: nil},
+        %{id: 2, first_name: "Bob", last_name: nil},
+        %{id: 3, first_name: "Charlie", last_name: nil},
+        %{id: 4, first_name: "David", last_name: nil}
+      ])
+
+      # Get first page with coalescing - this works
+      assert {:ok, %{edges: first_page, page_info: page_info}} =
+               KC.from_query(
+                 User,
+                 &Repo.all/1,
+                 %{
+                   sorts: [%{last_name: :asc}],
+                   first: 2
+                 },
+                 %{
+                   unique_column: :id,
+                   null_coalesce: %{last_name: ""}
+                 }
+               )
+
+      assert length(first_page) == 2
+      assert page_info.has_next_page == true
+
+      # Navigate to second page - this now works without crashing
+      assert {:ok, %{edges: second_page, page_info: second_page_info}} =
+               KC.from_query(
+                 User,
+                 &Repo.all/1,
+                 %{
+                   sorts: [%{last_name: :asc}],
+                   first: 2,
+                   after: page_info.end_cursor
+                 },
+                 %{
+                   unique_column: :id,
+                   null_coalesce: %{last_name: ""}
+                 }
+               )
+
+      assert length(second_page) == 2
+      assert second_page_info.has_next_page == false
+      assert second_page_info.has_previous_page == true
+
+      # All 4 users should be retrieved across both pages
+      all_ids = (Enum.map(first_page, & &1.node.id) ++ Enum.map(second_page, & &1.node.id)) |> Enum.sort()
+      assert all_ids == [1, 2, 3, 4]
+    end
+
+    test "handles mixed NULL and non-NULL values with coalescing" do
+      # Insert users with mixed NULL and non-NULL values
+      insert_users([
+        %{id: 1, first_name: "Alice", last_name: nil},
+        %{id: 2, first_name: "Bob", last_name: "Brown"},
+        %{id: 3, first_name: "Charlie", last_name: nil},
+        %{id: 4, first_name: "David", last_name: "Davis"}
+      ])
+
+      # With coalescing, NULL values should be sorted as empty strings (first in ASC order)
+      assert {:ok, %{edges: first_page, page_info: page_info}} =
+               KC.from_query(
+                 User,
+                 &Repo.all/1,
+                 %{
+                   sorts: [%{last_name: :asc}],
+                   first: 2
+                 },
+                 %{
+                   unique_column: :id,
+                   null_coalesce: %{last_name: ""}
+                 }
+               )
+
+      # First page should have the NULL values (coalesced to "") which come first
+      assert length(first_page) == 2
+      assert Enum.all?(first_page, fn edge -> edge.node.last_name == nil end)
+
+      # Second page should have the non-NULL values
+      assert {:ok, %{edges: second_page}} =
+               KC.from_query(
+                 User,
+                 &Repo.all/1,
+                 %{
+                   sorts: [%{last_name: :asc}],
+                   first: 2,
+                   after: page_info.end_cursor
+                 },
+                 %{
+                   unique_column: :id,
+                   null_coalesce: %{last_name: ""}
+                 }
+               )
+
+      assert length(second_page) == 2
+      assert Enum.all?(second_page, fn edge -> edge.node.last_name != nil end)
+      
+      # Should be sorted alphabetically
+      last_names = Enum.map(second_page, & &1.node.last_name) |> Enum.sort()
+      assert last_names == ["Brown", "Davis"]
+    end
+
+    test "supports backward pagination with NULL values and coalescing" do
+      # Insert 4 users with NULL values
+      insert_users([
+        %{id: 1, first_name: "Alice", last_name: nil},
+        %{id: 2, first_name: "Bob", last_name: nil},
+        %{id: 3, first_name: "Charlie", last_name: nil},
+        %{id: 4, first_name: "David", last_name: nil}
+      ])
+
+      # Get last 2 records
+      assert {:ok, %{edges: last_page, page_info: page_info}} =
+               KC.from_query(
+                 User,
+                 &Repo.all/1,
+                 %{
+                   sorts: [%{last_name: :asc}],
+                   last: 2
+                 },
+                 %{
+                   unique_column: :id,
+                   null_coalesce: %{last_name: ""}
+                 }
+               )
+
+      assert length(last_page) == 2
+      assert page_info.has_previous_page == true
+
+      # Navigate backward to first 2 records
+      assert {:ok, %{edges: first_page, page_info: first_page_info}} =
+               KC.from_query(
+                 User,
+                 &Repo.all/1,
+                 %{
+                   sorts: [%{last_name: :asc}],
+                   last: 2,
+                   before: page_info.start_cursor
+                 },
+                 %{
+                   unique_column: :id,
+                   null_coalesce: %{last_name: ""}
+                 }
+               )
+
+      assert length(first_page) == 2
+      assert first_page_info.has_previous_page == false
+
+      # All 4 users should be retrieved across both pages
+      all_ids = (Enum.map(first_page, & &1.node.id) ++ Enum.map(last_page, & &1.node.id)) |> Enum.sort()
+      assert all_ids == [1, 2, 3, 4]
+    end
+
+    test "supports multiple columns with different coalesce values" do
+      # Insert users with NULLs in different columns
+      insert_users([
+        %{id: 1, first_name: nil, last_name: nil},
+        %{id: 2, first_name: "Bob", last_name: nil},
+        %{id: 3, first_name: nil, last_name: "Charlie"},
+        %{id: 4, first_name: "David", last_name: "Davis"}
+      ])
+
+      # Use different coalesce values for different columns
+      assert {:ok, %{edges: edges}} =
+               KC.from_query(
+                 User,
+                 &Repo.all/1,
+                 %{
+                   sorts: [%{first_name: :asc}, %{last_name: :asc}],
+                   first: 4
+                 },
+                 %{
+                   unique_column: :id,
+                   null_coalesce: %{first_name: "AAA", last_name: "ZZZ"}
+                 }
+               )
+
+      assert length(edges) == 4
+
+      # Verify sorting order with coalesced values
+      # NULL first_name becomes "AAA", NULL last_name becomes "ZZZ"
+      names = Enum.map(edges, fn edge -> 
+        {edge.node.first_name || "AAA", edge.node.last_name || "ZZZ", edge.node.id}
+      end)
+      
+      # Should be sorted by first_name, then last_name
+      assert names == Enum.sort(names)
+    end
+  end
 end

--- a/test/absinthe_relay_keyset_connection_test.exs
+++ b/test/absinthe_relay_keyset_connection_test.exs
@@ -1265,7 +1265,9 @@ defmodule AbsintheRelayKeysetConnectionTest do
       assert second_page_info.has_previous_page == true
 
       # All 4 users should be retrieved across both pages
-      all_ids = (Enum.map(first_page, & &1.node.id) ++ Enum.map(second_page, & &1.node.id)) |> Enum.sort()
+      all_ids =
+        (Enum.map(first_page, & &1.node.id) ++ Enum.map(second_page, & &1.node.id)) |> Enum.sort()
+
       assert all_ids == [1, 2, 3, 4]
     end
 
@@ -1315,7 +1317,7 @@ defmodule AbsintheRelayKeysetConnectionTest do
 
       assert length(second_page) == 2
       assert Enum.all?(second_page, fn edge -> edge.node.last_name != nil end)
-      
+
       # Should be sorted alphabetically
       last_names = Enum.map(second_page, & &1.node.last_name) |> Enum.sort()
       assert last_names == ["Brown", "Davis"]
@@ -1368,7 +1370,9 @@ defmodule AbsintheRelayKeysetConnectionTest do
       assert first_page_info.has_previous_page == false
 
       # All 4 users should be retrieved across both pages
-      all_ids = (Enum.map(first_page, & &1.node.id) ++ Enum.map(last_page, & &1.node.id)) |> Enum.sort()
+      all_ids =
+        (Enum.map(first_page, & &1.node.id) ++ Enum.map(last_page, & &1.node.id)) |> Enum.sort()
+
       assert all_ids == [1, 2, 3, 4]
     end
 
@@ -1400,10 +1404,11 @@ defmodule AbsintheRelayKeysetConnectionTest do
 
       # Verify sorting order with coalesced values
       # NULL first_name becomes "AAA", NULL last_name becomes "ZZZ"
-      names = Enum.map(edges, fn edge -> 
-        {edge.node.first_name || "AAA", edge.node.last_name || "ZZZ", edge.node.id}
-      end)
-      
+      names =
+        Enum.map(edges, fn edge ->
+          {edge.node.first_name || "AAA", edge.node.last_name || "ZZZ", edge.node.id}
+        end)
+
       # Should be sorted by first_name, then last_name
       assert names == Enum.sort(names)
     end


### PR DESCRIPTION
Hi again!

I encountered an issue when trying to paginate and sort with `NULL` values in my data - this makes total sense as we encode the value and use it in SQL comparison to fetch the next page. While I should fix my data, I thought it could perhaps be a configurable option to `COALESCE` for you. What do you think?

It's a non-breaking change as you have to opt in and pass the coalesce value per column when you want to use it.

I've added the tests to cover both the failing scenario I experienced and then success with the new config.