### PR TITLE
Coalesce with distinct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.1.1 (2025-07-10)
+
+- Account for edge cases with `null_coalesce` and `distinct` queries
+
 ## v2.1.0 (2025-07-10)
 
 - Add `null_coalesce` option, thanks to @tomasz-tomczyk


### PR DESCRIPTION
In https://github.com/nathanl/absinthe_relay_keyset_connection/pull/5 we added ability to dynamically `COALESCE` nullable columns to enable cursor pagination on those; however when combined with `DISTINCT`, Postgres blows up demanding that the `ORDER BY` columns are included in the `SELECT`

This PR will nest a select where we get your requested data and the coalesce'd columns and then surface just the record you wanted (credit to @lostkobrakai for the idea in [Slack](https://elixir-lang.slack.com/archives/C087B66BY/p1752162009582869)), but unfortunately doesn't work out of the box if you have a custom select in your base query - in that case we return an error.

Provided tests for the edge cases I could think of, extended docs and a documented workaround for the edge case where you need the combination of:
* custom select
* distinct
* coalece nullable columns

It's a bit convoluted (sorry!) but works and is only messy in this edge case of doing all 3 things.