### PR TITLE
Fix Date/DateTime type handling in cursor decoding

### DIFF
--- a/test/absinthe_relay_keyset_connection/cursor_translator/base64_hashed_test.exs
+++ b/test/absinthe_relay_keyset_connection/cursor_translator/base64_hashed_test.exs
@@ -33,11 +33,11 @@ defmodule AbsintheRelayKeysetConnection.CursorTranslator.Base64HashedTest do
     test "with Date type in null_coalesce config" do
       # When using null_coalesce with Date structs, the decoded cursor should
       # return Date structs, not ISO8601 strings
-      columns = [:due_date, :id]
+      columns = [:date_of_birth, :id]
 
-      # Simulate a NULL date being coalesced to a default date
-      raw = %{due_date: nil, id: 1}
-      config = %{null_coalesce: %{due_date: ~D[0001-01-01]}}
+      # Simulate a NULL date_of_birth being coalesced to a default date
+      raw = %{date_of_birth: nil, id: 1}
+      config = %{null_coalesce: %{date_of_birth: ~D[0001-01-01]}}
 
       # When encoding, the nil date gets replaced with the default Date struct
       encoded = Base64Hashed.from_key(raw, columns, config)
@@ -45,9 +45,9 @@ defmodule AbsintheRelayKeysetConnection.CursorTranslator.Base64HashedTest do
       # When decoding, the Date should be properly converted back from JSON string
       {:ok, decoded} = Base64Hashed.to_key(encoded, columns, config)
 
-      # The decoded due_date should be a Date struct, not a string
-      assert decoded.due_date == ~D[0001-01-01]
-      assert %Date{} = decoded.due_date
+      # The decoded date_of_birth should be a Date struct, not a string
+      assert decoded.date_of_birth == ~D[0001-01-01]
+      assert %Date{} = decoded.date_of_birth
       assert decoded.id == 1
     end
 

--- a/test/support/priv/repo/migrations/20250119165543_add_date_of_birth_to_users.exs
+++ b/test/support/priv/repo/migrations/20250119165543_add_date_of_birth_to_users.exs
@@ -1,0 +1,9 @@
+defmodule AbsintheRelayKeysetConnection.Repo.Migrations.AddDateOfBirthToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add(:date_of_birth, :date)
+    end
+  end
+end

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -8,5 +8,6 @@ defmodule AbsintheRelayKeysetConnection.User do
   schema "users" do
     field(:first_name, :string)
     field(:last_name, :string)
+    field(:date_of_birth, :date)
   end
 end


### PR DESCRIPTION
Hello again! Follow up to the feature added in https://github.com/nathanl/absinthe_relay_keyset_connection/pull/5

When encoding cursors, Date and DateTime structs from null_coalesce values are serialized to ISO8601 strings using Jason (e.g., `~D[0001-01-01]` becomes `"0001-01-01"`). However, when decoding cursors, these strings weren't being converted back to their proper Elixir types. This caused Postgrex to reject them when they were used in SQL WHERE clauses during pagination.

The bug only appeared when:
1. Using `null_coalesce` config with Date/DateTime default values
2. Navigating to the second page of results (first page has no cursor, so no decoding occurs)

When navigating to the second page of paginated results with nullable date columns, queries would fail with:

```
** (Postgrex.Error) ERROR 08P01 (protocol_violation) invalid date (year, month, day): 0001-01-01
** (ArgumentError) Postgrex expected %Date{}, got "0001-01-01"
```

The fix is fairly simple as we can derive the type from the thing we passed into `null_coalesce` and convert back.